### PR TITLE
Bump minimal requirements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: main
+name: tox
 
 on:
   push:
@@ -15,18 +15,19 @@ on:
 
 jobs:
   build:
+    name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
         name: [
-          "ubuntu-py27",
-          "ubuntu-py36",
-          "ubuntu-py37",
-          "ubuntu-py38",
           "linting",
           "packaging",
+          "py36",
+          "py37",
+          "py38",
+          "devel",
         ]
         os: [
           "ubuntu-latest",
@@ -34,31 +35,30 @@ jobs:
 
         include:
 
-          - name: "ubuntu-py27"
-            python: "2.7"
-            os: ubuntu-latest
-            tox_env: "py27"
-          - name: "ubuntu-py36"
-            python: "3.6"
-            os: ubuntu-latest
-            tox_env: "py36"
-          - name: "ubuntu-py37"
-            python: "3.7"
-            os: ubuntu-latest
-            tox_env: "py37"
-          - name: "ubuntu-py38"
-            python: "3.8"
-            os: ubuntu-latest
-            tox_env: "py38"
-
           - name: "linting"
-            python: "3.7"
+            python: "3.6"
             os: ubuntu-latest
             tox_env: "linting"
           - name: "packaging"
-            python: "3.7"
+            python: "3.6"
             os: ubuntu-latest
             tox_env: "packaging"
+          - name: py36
+            python: "3.6"
+            os: ubuntu-latest
+            tox_env: py36
+          - name: py37
+            python: "3.7"
+            os: ubuntu-latest
+            tox_env: py37
+          - name: py38
+            python: "3.8"
+            os: ubuntu-latest
+            tox_env: py38
+          - name: devel
+            python: "3.8"
+            os: ubuntu-latest
+            tox_env: devel
 
     steps:
       - uses: actions/checkout@v1
@@ -72,3 +72,70 @@ jobs:
           pip install tox
       - name: Test
         run: "tox -e ${{ matrix.tox_env }}"
+
+  publish:
+    name: Publish to PyPI registry
+    needs:
+      - build
+    runs-on: ubuntu-latest
+
+    env:
+      PY_COLORS: 1
+      TOXENV: packaging
+
+    steps:
+      - name: Switch to using Python 3.6 by default
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Install tox
+        run: python -m pip install --user tox
+      - name: Check out src from Git
+        uses: actions/checkout@v2
+        with:
+          # Get shallow Git history (default) for tag creation events
+          # but have a complete clone for any other workflows.
+          # Both options fetch tags but since we're going to remove
+          # one from HEAD in non-create-tag workflows, we need full
+          # history for them.
+          fetch-depth: >-
+            ${{
+              (
+                github.event_name == 'create' &&
+                github.event.ref_type == 'tag'
+              ) &&
+              1 || 0
+            }}
+      - name: Drop Git tags from HEAD for non-tag-create events
+        if: >-
+          github.event_name != 'create' ||
+          github.event.ref_type != 'tag'
+        run: >-
+          git tag --points-at HEAD
+          |
+          xargs git tag --delete
+      - name: Build dists
+        run: python -m tox
+      - name: Publish to test.pypi.org
+        if: >-
+          (
+            github.event_name == 'push' &&
+            github.ref == format(
+              'refs/heads/{0}', github.event.repository.default_branch
+            )
+          ) ||
+          (
+            github.event_name == 'create' &&
+            github.event.ref_type == 'tag'
+          )
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.testpypi_password }}
+          repository_url: https://test.pypi.org/legacy/
+      - name: Publish to pypi.org
+        if: >-  # "create" workflows run separately from "push" & "pull_request"
+          github.event_name == 'create' &&
+          github.event.ref_type == 'tag'
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.pypi_password }}

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/pytest-plus.svg)](https://pypi.org/project/pytest-plus)
 [![Python versions](https://img.shields.io/pypi/pyversions/pytest-plus.svg)](https://pypi.org/project/pytest-plus)
-![CI](https://github.com/pytest-dev/pytest-plus/workflows/main/badge.svg)
+![CI](https://github.com/pytest-dev/pytest-plus/workflows/tox/badge.svg)
 [![Python Black Code Style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 
-This plugin aims to be used to host multiple pytest extensions that meet the
-following criteria:
+This plugin aims to be used to host multiple basic pytest extensions that meet
+the following criteria:
 
-* Keep py27 compatibility for the moment
+* Keep py36 compatibility
 * Downgrade gracefully, meaning that if the plugin is removed, you will still
   be able to run pytest
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,10 +31,7 @@ classifiers =
     License :: OSI Approved :: MIT License
     Natural Language :: English
     Operating System :: OS Independent
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -51,7 +48,7 @@ keywords =
 
 [options]
 use_scm_version = True
-python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*
+python_requires = >=3.6
 packages = find:
 include_package_data = True
 zip_safe = False
@@ -62,10 +59,8 @@ setup_requires =
     setuptools_scm_git_archive >= 1.0
 
 install_requires =
-    pytest >= 3.50
-    # https://github.com/pytest-dev/pytest/issues/5854
-    more_itertools >= 5, < 6; python_version<"3.0"
-    more_itertools >= 6; python_version>="3.0"
+    pytest >= 6.0.1
+    more_itertools >= 8.4.0
 
 [options.extras_require]
 test =

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     linting
     devel
     packaging
-    py{27,35,36,37,38}
+    py{36,37,38}
 skipsdist = True
 isolated_build = True
 


### PR DESCRIPTION
py36 and pytest>=6.0.1 are minimal supported now. This counts as a breaking change so will require correct versioning.