### PR TITLE
Activate prettier-plugin-toml in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
           - prettier
           - prettier-plugin-toml
           - prettier-plugin-sort-json
+        args: [--plugin, prettier-plugin-toml]
   - repo: https://github.com/PyCQA/doc8.git
     rev: v1.1.1
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools >= 63.0.0", # required by pyproject+setuptools_scm integration
+  "setuptools >= 63.0.0",          # required by pyproject+setuptools_scm integration
   "setuptools_scm[toml] >= 7.0.5", # required for "no-local-version" scheme
 
 ]
@@ -15,7 +15,7 @@ description = "PyTest Plus Plugin :: extends pytest functionality"
 readme = "README.md"
 authors = [{ "name" = "Sorin Sbarnea", "email" = "sorin.sbarnea@gmail.com" }]
 maintainers = [
-  { "name" = "Sorin Sbarnea", "email" = "sorin.sbarnea@gmail.com" }
+  { "name" = "Sorin Sbarnea", "email" = "sorin.sbarnea@gmail.com" },
 ]
 license = { text = "MIT" }
 classifiers = [


### PR DESCRIPTION
In the pre-commit hook, the plugin prettier-plugin-toml is installed, but not used.
Plugins must be loaded either via CLI argument `--plugin` or in the configuration file.
As there is now configuration file in this project, I added it as argument.

For more information, see [prettier docs](https://prettier.io/docs/en/plugins#using-plugins).