### PR TITLE
Make log collection more resilient

### DIFF
--- a/src/pytest_plus/__init__.py
+++ b/src/pytest_plus/__init__.py
@@ -53,11 +53,16 @@ def pytest_sessionfinish(session: pytest.Session) -> None:
     # copy all pytest own logs inside $VIRTUAL_ENV/log, for collection.
     venv = os.environ.get("VIRTUAL_ENV", "")
     if os.environ.get("CI", "0") != "0" and venv:
-        shutil.copytree(
-            src=session.config._tmp_path_factory.getbasetemp(),  # type: ignore[attr-defined] # noqa: SLF001
-            dst=venv + "/log",
-            dirs_exist_ok=True,
-        )
+        # Copy can fail if the source folder was already removed, but we
+        # should not fail due to this.
+        try:
+            shutil.copytree(
+                src=session.config._tmp_path_factory.getbasetemp(),  # type: ignore[attr-defined] # noqa: SLF001
+                dst=venv + "/log",
+                dirs_exist_ok=True,
+            )
+        except OSError as e:
+            _logger.warning("Failed to copy pytest logs to $VIRTUAL_ENV/log: %s", e)
 
 
 @pytest.hookimpl(tryfirst=True)  # type: ignore[misc,unused-ignore]


### PR DESCRIPTION
As we observed that sometimes log collection can fail due to source
folder being removed, we just log these failures as warnings.
